### PR TITLE
Corrige l'arrondi des notes et les pondérations des évaluations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/hooks/useReprogrammationSeances.ts
+++ b/src/hooks/useReprogrammationSeances.ts
@@ -159,11 +159,15 @@ export function useReprogrammationSeances() {
       creneauxOccupes.delete(`${seance.date}-${heure}`);
       newDates[i] = candidateIso;
       creneauxOccupes.add(`${candidateIso}-${heure}`);
-      // Marquer les séances dans l'intervalle comme reportées
-      if (impactedIndices.includes(i)) {
-        seancesOriginalOrder[i].estReportee = true;
+      // Toutes les séances déplacées gardent une trace de leur date d'origine afin
+      // de pouvoir annuler la reprogrammation si l'absence est supprimée.
+      if (i >= firstImpacted) {
         seancesOriginalOrder[i].absenceOriginId = absence.id as any;
         seancesOriginalOrder[i].dateOriginale = seance.date;
+      }
+      // Les séances initialement dans l'intervalle d'absence sont marquées comme reportées
+      if (impactedIndices.includes(i)) {
+        seancesOriginalOrder[i].estReportee = true;
         nbReportees++;
       }
     }
@@ -232,7 +236,10 @@ export function useReprogrammationSeances() {
           return seance;
         });
         if (modifie) {
-          updateCycle(cycle.id, { seances: seancesRestituees });
+          updateCycle(cycle.id, {
+            seances: seancesRestituees,
+            updatedAt: new Date().toISOString()
+          });
         }
       });
     }

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -6,7 +6,12 @@ import type { Niveau, Dims } from '../types';
  */
 export function roundHalf(note: number): number {
   const clamped = Math.max(0, Math.min(20, note));
-  return Math.round(clamped * 2) / 2;
+  const floored = Math.floor(clamped * 10) / 10; // tronquer à 1 décimale
+  const base = Math.floor(floored);
+  const decimal = floored - base;
+  if (decimal >= 0.75) return base + 1;
+  if (decimal >= 0.25) return base + 0.5;
+  return base;
 }
 
 /**
@@ -30,9 +35,10 @@ export function computeNoteFinale(niveau: Niveau, dims: Dims): number {
     total += get('connaissances') * 10;
     coeff = 100;
   } else if (niveau === '2ème Bac') {
-    total += get('projet') * 40;
-    total += get('tactique') * 30;
-    total += get('comportement') * 20;
+    // Pondérations spécifiques : projet 50 %, tactique 25 %, comportement 15 %, connaissances 10 %
+    total += get('projet') * 50;
+    total += get('tactique') * 25;
+    total += get('comportement') * 15;
     total += get('connaissances') * 10;
     coeff = 100;
   }


### PR DESCRIPTION
## Summary
- Réécriture de `roundHalf` pour un arrondi à la demi-unité inférieur/ supérieur après troncature
- Ajustement des coefficients pour le niveau "2ème Bac"
- Ajout d'un `.gitignore` pour les artefacts locaux
- Sauvegarde la date originale de toutes les séances reprogrammées et restaure le cycle lors de la suppression d'une absence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0399680448328803442e1a0319664