### PR TITLE
Corrige l'arrondi des notes et les pondérations des évaluations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/data/objectifs.ts
+++ b/src/data/objectifs.ts
@@ -504,9 +504,9 @@ const MODULES_DATA: Record<ModuleNumero, ModuleObjectifs> = {
           "Saut réglementaire.",
           "Évaluation finale."
         ]
-      }
-    ],
-  },
+      },
+      ],
+    },
 
   // ────────────────────────────────────────────────────────────────────────────
   4: {
@@ -743,7 +743,7 @@ const MODULES_DATA: Record<ModuleNumero, ModuleObjectifs> = {
         ]
       },
       { 
-        aps: "Athlétisme — Lancer de poids", 
+        aps: "Athlétisme — Lancer de poids",
         seances: [
           "Tenue de l'engin (bases des doigts, coude levé).",
           "Lever l'engin, bras en arrière, ouvrir buste/hanche, bras libre (rattrapage).",
@@ -757,6 +757,74 @@ const MODULES_DATA: Record<ModuleNumero, ModuleObjectifs> = {
           "Évaluation formative.",
           "Évaluation sommative.",
           "—"
+        ]
+      },
+      {
+        aps: "Handball",
+        seances: [
+          "Détecter niveau individuel/collectif (progression, conservation, efficacité attaque/défense).",
+          "Différents types de passes en égalité numérique.",
+          "Donner et réceptionner en mouvement.",
+          "Jouer en mouvement jusqu'à la zone de marque et tirer.",
+          "Passes précises et rapides en supériorité numérique.",
+          "Se démarquer dans les zones libres (égalité).",
+          "Respecter son poste et avancer collectivement.",
+          "Pré-test.",
+          "Défendre son poste puis s'organiser pour contre-attaquer.",
+          "Choix alternatif passe/dribble (égalité).",
+          "Se situer en appui/soutien pour favoriser l'échange.",
+          "Évaluation en match (individuel/collectif)."
+        ]
+      },
+      {
+        aps: "Gymnastique au sol",
+        seances: [
+          "Évaluation diagnostique (fiche de niveau).",
+          "Éléments A + liaisons.",
+          "Consolider A.",
+          "Éléments B.",
+          "Consolider B.",
+          "Éléments C avec aide/parade.",
+          "Consolider C.",
+          "Mini-enchaînement 2A+2B.",
+          "Mini-enchaînement 2A+1B+1C.",
+          "Enchaînement 2A+2B+1C.",
+          "Préparer 2A+3B+2C.",
+          "Évaluation finale (enchaînement complet)."
+        ]
+      },
+      {
+        aps: "Athlétisme — Course de vitesse",
+        seances: [
+          "Observer le niveau initial.",
+          "Position des appuis au départ.",
+          "Réagir rapidement (positions du corps).",
+          "Réagir aux signaux visuels/auditifs.",
+          "Se positionner au starting-block (prise de contact).",
+          "Conscience du pied de poussée + passage du pied libre.",
+          "Redressement progressif + synchro bras/jambes.",
+          "Trajet rectiligne + positionnement du pied en fin de course.",
+          "Trajet rectiligne à rythme variable.",
+          "Bon départ + redressement + course rythmique.",
+          "Bon départ + redressement + course axée.",
+          "Évaluation (80m G / 60m F)."
+        ]
+      },
+      {
+        aps: "Athlétisme — Saut en longueur",
+        seances: [
+          "Détecter le niveau initial.",
+          "Étalonner course d'élan + impulsion.",
+          "Recherche de course optimale.",
+          "Ajuster le pied d'appel (3 dernières foulées).",
+          "Liaison course–impulsion sans perte.",
+          "Saut avec angle optimal.",
+          "Suspension — ouverture.",
+          "Suspension — ramené.",
+          "Réception vers l'avant.",
+          "Pré-test des acquis.",
+          "Saut réglementaire.",
+          "Évaluation finale."
         ]
       }
     ],

--- a/src/hooks/useReprogrammationSeances.ts
+++ b/src/hooks/useReprogrammationSeances.ts
@@ -159,11 +159,15 @@ export function useReprogrammationSeances() {
       creneauxOccupes.delete(`${seance.date}-${heure}`);
       newDates[i] = candidateIso;
       creneauxOccupes.add(`${candidateIso}-${heure}`);
-      // Marquer les séances dans l'intervalle comme reportées
-      if (impactedIndices.includes(i)) {
-        seancesOriginalOrder[i].estReportee = true;
+      // Toutes les séances déplacées gardent une trace de leur date d'origine afin
+      // de pouvoir annuler la reprogrammation si l'absence est supprimée.
+      if (i >= firstImpacted) {
         seancesOriginalOrder[i].absenceOriginId = absence.id as any;
         seancesOriginalOrder[i].dateOriginale = seance.date;
+      }
+      // Les séances initialement dans l'intervalle d'absence sont marquées comme reportées
+      if (impactedIndices.includes(i)) {
+        seancesOriginalOrder[i].estReportee = true;
         nbReportees++;
       }
     }
@@ -232,7 +236,10 @@ export function useReprogrammationSeances() {
           return seance;
         });
         if (modifie) {
-          updateCycle(cycle.id, { seances: seancesRestituees });
+          updateCycle(cycle.id, {
+            seances: seancesRestituees,
+            updatedAt: new Date().toISOString()
+          });
         }
       });
     }

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -6,7 +6,12 @@ import type { Niveau, Dims } from '../types';
  */
 export function roundHalf(note: number): number {
   const clamped = Math.max(0, Math.min(20, note));
-  return Math.round(clamped * 2) / 2;
+  const floored = Math.floor(clamped * 10) / 10; // tronquer à 1 décimale
+  const base = Math.floor(floored);
+  const decimal = floored - base;
+  if (decimal >= 0.75) return base + 1;
+  if (decimal >= 0.25) return base + 0.5;
+  return base;
 }
 
 /**
@@ -30,9 +35,10 @@ export function computeNoteFinale(niveau: Niveau, dims: Dims): number {
     total += get('connaissances') * 10;
     coeff = 100;
   } else if (niveau === '2ème Bac') {
-    total += get('projet') * 40;
-    total += get('tactique') * 30;
-    total += get('comportement') * 20;
+    // Pondérations spécifiques : projet 50 %, tactique 25 %, comportement 15 %, connaissances 10 %
+    total += get('projet') * 50;
+    total += get('tactique') * 25;
+    total += get('comportement') * 15;
     total += get('connaissances') * 10;
     coeff = 100;
   }


### PR DESCRIPTION
## Summary
- Réécriture de `roundHalf` pour un arrondi à la demi-unité inférieur/ supérieur après troncature
- Ajustement des coefficients pour le niveau "2ème Bac"
- Ajout d'un `.gitignore` pour les artefacts locaux
- Sauvegarde la date originale de toutes les séances reprogrammées et restaure le cycle lors de la suppression d'une absence
- Complète la liste des APS du module 5 pour proposer 9 activités au niveau "2ème Bac"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b0399680448328803442e1a0319664